### PR TITLE
Adding boundary polygon into metadata

### DIFF
--- a/app/rtc_s1.py
+++ b/app/rtc_s1.py
@@ -868,7 +868,9 @@ def run(cfg):
                            clip_max, clip_min, output_radiometry_str,
                            output_file_list, cfg.geogrid, pol_list,
                            geo_filename, nlooks_mosaic_file,
-                           rtc_anf_mosaic_file, radar_grid_file_dict,
+                           rtc_anf_mosaic_file, 
+                           layover_shadow_mask_file, # TODO Decide if we will mosaic layover/shadow mask when save_mosaic is True
+                           radar_grid_file_dict,
                            save_imagery = save_imagery_as_hdf5)
 
     if output_imagery_format == 'COG':


### PR DESCRIPTION
This PR is to add the bounding polygon information into the `.h5` metadata.
- As discussed, the geometry will be `MULTIPOLYGON` when the polygon crosses the antimeridian, and `Sentinel1BurstSlc.border` consists of multiple polygons. Otherwise, it will be a single `POLYGON`

I've also added a TODO on the mosaicking part in order not to forget to make sure if it works as we expected for the layover/shadow mask we recently added.