### PR TITLE
Fix on child process logging

### DIFF
--- a/src/rtc/rtc_s1.py
+++ b/src/rtc/rtc_s1.py
@@ -281,6 +281,7 @@ def process_child_runconfig_subprocess(path_runconfig_burst,
     result_child_process: int
         0 when the child process has completed succesfully
     '''
+    os.environ['OMP_NUM_THREADS'] = "1"
     list_arg_subprocess = ['rtc_s1_single_job.py', path_runconfig_burst]
 
     if path_burst_logfile is not None: 

--- a/src/rtc/rtc_s1.py
+++ b/src/rtc/rtc_s1.py
@@ -220,50 +220,7 @@ def process_child_runconfig(path_runconfig_burst,
                             flag_full_logfile_format=None,
                             keep_burst_runconfig=False):
     '''
-    single worker to process runconfig from terminal using `subprocess`
-
-    Parameters
-    ----------
-    path_runconfig_burst: str
-        Path to the burst runconfig
-    path_burst_logfile: str
-        Path to the burst logfile
-    full_log_format: bool
-        Enable full formatting of log messages.
-        See `get_rtc_s1_parser()`
-    keep_burst_runconfig: bool
-        Keep the child runconfig when `True`;
-        delete it after done with the processing when `False`
-
-    Returns
-    -------
-    result_child_process: int
-        0 when the child process has completed succesfully
-    '''
-    # Get a runconfig dict from command line argumens
-    workflow_name = 'rtc_s1'
-    cfg = RunConfig.load_from_yaml(path_runconfig_burst, workflow_name)
-
-    load_parameters(cfg)
-
-    create_logger(path_burst_logfile, flag_full_logfile_format)
-
-    # Run geocode burst workflow
-    result_child_process = run_single_job(cfg)
-
-    # Remove or keep (for debugging purpose) the processed runconfig
-    if keep_burst_runconfig:
-        os.remove(path_runconfig_burst)
-
-    return result_child_process
-
-
-def process_child_runconfig_subprocess(path_runconfig_burst,
-                            path_burst_logfile=None,
-                            flag_full_logfile_format=None,
-                            keep_burst_runconfig=False):
-    '''
-    single worker to process runconfig from terminal using `subprocess`
+    single worker to process runconfig using `subprocess`
     Parameters
     ----------
     path_runconfig_burst: str
@@ -540,7 +497,7 @@ def run_parallel(cfg: RunConfig, logfile_path, flag_logger_full_format):
     # Execute the single burst processes using multiprocessing
     with multiprocessing.Pool(num_workers) as p:
         processing_result_list =\
-            p.starmap(process_child_runconfig_subprocess,
+            p.starmap(process_child_runconfig,
                       zip(burst_runconfig_list,
                           burst_log_list,
                           repeat(flag_logger_full_format)

--- a/src/rtc/rtc_s1.py
+++ b/src/rtc/rtc_s1.py
@@ -294,7 +294,7 @@ def process_child_runconfig_subprocess(path_runconfig_burst,
     if not keep_burst_runconfig:
         os.remove(path_runconfig_burst)
 
-    return rtnval
+    return rtnval.returncode
 
 
 def run_parallel(cfg: RunConfig, logfile_path, flag_logger_full_format):

--- a/src/rtc/rtc_s1.py
+++ b/src/rtc/rtc_s1.py
@@ -6,6 +6,7 @@ from itertools import repeat
 import logging
 import multiprocessing
 import os
+import subprocess
 import time
 import yaml
 
@@ -257,6 +258,45 @@ def process_child_runconfig(path_runconfig_burst,
     return result_child_process
 
 
+def process_child_runconfig_subprocess(path_runconfig_burst,
+                            path_burst_logfile=None,
+                            flag_full_logfile_format=None,
+                            keep_burst_runconfig=False):
+    '''
+    single worker to process runconfig from terminal using `subprocess`
+    Parameters
+    ----------
+    path_runconfig_burst: str
+        Path to the burst runconfig
+    path_burst_logfile: str
+        Path to the burst logfile
+    full_log_format: bool
+        Enable full formatting of log messages.
+        See `get_rtc_s1_parser()`
+    keep_burst_runconfig: bool
+        Keep the child runconfig when `True`;
+        delete it after done with the processing when `False`
+    Returns
+    -------
+    result_child_process: int
+        0 when the child process has completed succesfully
+    '''
+    list_arg_subprocess = ['rtc_s1_single_job.py', path_runconfig_burst]
+
+    if path_burst_logfile is not None: 
+        list_arg_subprocess += ['--log-file', path_burst_logfile]
+
+    if flag_full_logfile_format:
+        list_arg_subprocess.append('--full-log-format')
+
+    rtnval = subprocess.run(list_arg_subprocess)
+
+    if not keep_burst_runconfig:
+        os.remove(path_runconfig_burst)
+
+    return rtnval
+
+
 def run_parallel(cfg: RunConfig, logfile_path, flag_logger_full_format):
     '''
     Run RTC workflow with user-defined args
@@ -499,7 +539,7 @@ def run_parallel(cfg: RunConfig, logfile_path, flag_logger_full_format):
     # Execute the single burst processes using multiprocessing
     with multiprocessing.Pool(num_workers) as p:
         processing_result_list =\
-            p.starmap(process_child_runconfig,
+            p.starmap(process_child_runconfig_subprocess,
                       zip(burst_runconfig_list,
                           burst_log_list,
                           repeat(flag_logger_full_format)

--- a/src/rtc/rtc_s1.py
+++ b/src/rtc/rtc_s1.py
@@ -290,12 +290,12 @@ def process_child_runconfig_subprocess(path_runconfig_burst,
     if flag_full_logfile_format:
         list_arg_subprocess.append('--full-log-format')
 
-    rtnval = subprocess.run(list_arg_subprocess)
+    child_processing_result = subprocess.run(list_arg_subprocess)
 
     if not keep_burst_runconfig:
         os.remove(path_runconfig_burst)
 
-    return rtnval.returncode
+    return child_processing_result.returncode
 
 
 def run_parallel(cfg: RunConfig, logfile_path, flag_logger_full_format):

--- a/src/rtc/rtc_s1_single_job.py
+++ b/src/rtc/rtc_s1_single_job.py
@@ -260,7 +260,8 @@ def compute_layover_shadow_mask(radar_grid: isce3.product.RadarGridParameters,
                                 extraiter_rdr2geo: int=10,
                                 lines_per_block_rdr2geo: int=1000,
                                 threshold_geo2rdr: float=1.0e-7,
-                                numiter_geo2rdr: int=25):
+                                numiter_geo2rdr: int=25,
+                                memory_mode: str=''):
     '''
     Compute the layover/shadow mask and geocode it
 
@@ -353,7 +354,8 @@ def compute_layover_shadow_mask(radar_grid: isce3.product.RadarGridParameters,
                 input_raster=slantrange_layover_shadow_mask_raster,
                 output_raster=geocoded_layover_shadow_mask_raster,
                 dem_raster=dem_raster,
-                output_mode=isce3.geocode.GeocodeOutputMode.INTERP)
+                output_mode=isce3.geocode.GeocodeOutputMode.INTERP,
+                memory_mode=memory_mode)
 
     return slantrange_layover_shadow_mask_raster
 
@@ -772,7 +774,7 @@ def run_single_job(cfg: RunConfig):
                 layover_shadow_mask_file = \
                     (f'{output_dir_sec_bursts}/{product_prefix}'
                      f'_layover_shadow_mask.{imagery_extension}')
-
+            logger.info(f'Computing layover shadow mask for {burst_id}')
             slantrange_layover_shadow_mask_raster = compute_layover_shadow_mask(
                 radar_grid,
                 orbit,
@@ -784,7 +786,8 @@ def run_single_job(cfg: RunConfig):
                 threshold_rdr2geo=cfg.rdr2geo_params.threshold,
                 numiter_rdr2geo=cfg.rdr2geo_params.numiter,
                 threshold_geo2rdr=cfg.geo2rdr_params.threshold,
-                numiter_geo2rdr=cfg.geo2rdr_params.numiter)
+                numiter_geo2rdr=cfg.geo2rdr_params.numiter,
+                memory_mode=geocode_namespace.memory_mode)
 
             if flag_layover_shadow_mask_is_temporary:
                 temp_files_list.append(layover_shadow_mask_file)

--- a/src/rtc/rtc_s1_single_job.py
+++ b/src/rtc/rtc_s1_single_job.py
@@ -261,7 +261,7 @@ def compute_layover_shadow_mask(radar_grid: isce3.product.RadarGridParameters,
                                 lines_per_block_rdr2geo: int=1000,
                                 threshold_geo2rdr: float=1.0e-7,
                                 numiter_geo2rdr: int=25,
-                                memory_mode: str=''):
+                                memory_mode: str=None):
     '''
     Compute the layover/shadow mask and geocode it
 


### PR DESCRIPTION
This PR fixes the failure regarding the logging that was discovered during the test on the linux server. Previously, the child processes were triggered by imported `run()`. This fix makes use of `subprocess` to start the child process, so that the logger object between the parent process and the child processes are isolated.